### PR TITLE
Possible missing args

### DIFF
--- a/grouphug/heads/classification.py
+++ b/grouphug/heads/classification.py
@@ -236,7 +236,7 @@ class ClassificationHeadConfig(HeadConfig):
         num_labels=None,
         problem_type=None,
         extra_inputs_vars: List[str] = None,
-        num_extra_inputs: Optional[int] = None,
+        num_extra_inputs: Optional[int] = 0,
         pooling_method: str = "auto",
         classifier_hidden_size: Optional[int] = None,
         id2label: List[Any] = None,

--- a/grouphug/heads/classification.py
+++ b/grouphug/heads/classification.py
@@ -314,6 +314,8 @@ class ClassificationHeadConfig(HeadConfig):
             id2label=id2label,
             pooling_method=pooling_method,
             classifier_hidden_size=classifier_hidden_size,
+            num_extra_inputs=num_extra_inputs,
+            extra_inputs_vars=extra_inputs_vars,
             **kwargs,
         )
 


### PR DESCRIPTION
Hope you are doing well :)

args to handle extra inputs variables are missing in classmethod constructor `_from_data`.

```python
cls_head = ClassificationHeadConfig.from_data(
        data,
        labels_var="target",
        extra_inputs_vars=["extra_var"],
    )

cls_head.extra_inputs_vars  # Result: []
```
The expected output is `["extra_var"]`
